### PR TITLE
Close a parentheses to fix a syntax error

### DIFF
--- a/group-checker.py
+++ b/group-checker.py
@@ -41,7 +41,7 @@ def checkGroup():
         print(f"[Info] Proxy error, switching proxy [{oldproxy} -> {currentProxy}]")
 
 if __name__ ==  '__main__':
-  print("Roblox Group Checker made by SirWeeb (https://www.novaline.xyz)"
+  print("Roblox Group Checker made by SirWeeb (https://www.novaline.xyz)")
   open("unclaimable_groups.txt", "w").close() # Will make the file if not there & clear them
   open("claimable_groups.txt", "w").close() # Will make the file if not there & clear them
   checkGroup()


### PR DESCRIPTION
The print function was never closed, so a syntax error was triggered on execution.
I just closed that parentheses. Now, it seems to work.